### PR TITLE
Add human readable error message from PowerDNS API response

### DIFF
--- a/pdnshttp/errors.go
+++ b/pdnshttp/errors.go
@@ -23,6 +23,7 @@ func (e ErrUnexpectedStatus) Error() string {
 	return fmt.Sprintf("unexpected status code %d: %s %s", e.StatusCode, e.URL, e.ErrResponse.Message)
 }
 
+// ErrResponse represents error response from PowerDNS HTTP API
 type ErrResponse struct {
 	Message  string   `json:"error"`
 	Messages []string `json:"errors,omitempty"`

--- a/pdnshttp/errors.go
+++ b/pdnshttp/errors.go
@@ -13,10 +13,19 @@ func (e ErrNotFound) Error() string {
 type ErrUnexpectedStatus struct {
 	URL        string
 	StatusCode int
+	ErrResponse
 }
 
 func (e ErrUnexpectedStatus) Error() string {
-	return fmt.Sprintf("unexpected status code %d: %s", e.StatusCode, e.URL)
+	if len(e.ErrResponse.Messages) > 0 {
+		return fmt.Sprintf("unexpected status code %d: %s %s %s", e.StatusCode, e.URL, e.ErrResponse.Message, e.ErrResponse.Messages)
+	}
+	return fmt.Sprintf("unexpected status code %d: %s %s", e.StatusCode, e.URL, e.ErrResponse.Message)
+}
+
+type ErrResponse struct {
+	Message  string   `json:"error"`
+	Messages []string `json:"errors,omitempty"`
 }
 
 func IsNotFound(err error) bool {


### PR DESCRIPTION
Hey.
In my use case, I want to get the errors that PowerDNS API returns to diagnose problems.
For example, flushing the cache at the URL `/api/ v1/servers/{serverID}/cache/flush`, when requested without parameters, it returns `{" error ": "DNS Name '' is not canonical"}`.

With this patch I can see the error with the string
```
unexpected status code 422: http://127.0.0.1:8081/api/v1/servers/{serverID}/cache/flush?domain= DNS Name '' is not canonical
```
or in JSON
```
{
  "URL": "http://127.0.0.1:8081/api/v1/servers/localhost/cache/flush?domain=",
  "StatusCode": 422,
  "error": "DNS Name '' is not canonical"
}
```