### PR TITLE
Omit empty cryptokey attributes

### DIFF
--- a/apis/cryptokeys/types_cryptokey.go
+++ b/apis/cryptokeys/types_cryptokey.go
@@ -3,14 +3,14 @@ package cryptokeys
 // Cryptokey represents a Cryptokey model of the API
 // More information: https://doc.powerdns.com/authoritative/http-api/cryptokey.html#cryptokey
 type Cryptokey struct {
-	ID         int      `json:"id"`
-	Type       string   `json:"type"`
-	KeyType    string   `json:"keytype"`
-	Active     bool     `json:"active"`
-	Published  bool     `json:"published"`
-	DNSKey     string   `json:"dnskey"`
-	DS         []string `json:"ds"`
-	PrivateKey string   `json:"privatekey"`
-	Algorithm  string   `json:"algorithm"`
-	Bits       int      `json:"bits"`
+	ID         int      `json:"id,omitempty"`
+	Type       string   `json:"type,omitempty"`
+	KeyType    string   `json:"keytype,omitempty"`
+	Active     bool     `json:"active,omitempty"`
+	Published  bool     `json:"published,omitempty"`
+	DNSKey     string   `json:"dnskey,omitempty"`
+	DS         []string `json:"ds,omitempty"`
+	PrivateKey string   `json:"privatekey,omitempty"`
+	Algorithm  string   `json:"algorithm,omitempty"`
+	Bits       int      `json:"bits,omitempty"`
 }


### PR DESCRIPTION
The crypto key attributes needed to be omitted when empty otherwise it is causing errors with the PDNS API.