### PR TITLE
Configure base path when constructing client

### DIFF
--- a/apis/cache/flush.go
+++ b/apis/cache/flush.go
@@ -10,7 +10,7 @@ import (
 
 func (c *client) Flush(ctx context.Context, serverID string, name string) (*FlushResult, error) {
 	cfr := FlushResult{}
-	path := fmt.Sprintf("/api/v1/servers/%s/cache/flush", url.PathEscape(serverID))
+	path := fmt.Sprintf("/servers/%s/cache/flush", url.PathEscape(serverID))
 
 	err := c.httpClient.Put(ctx, path, &cfr, pdnshttp.WithQueryValue("domain", name))
 	if err != nil {

--- a/apis/cryptokeys/cryptokey_create.go
+++ b/apis/cryptokeys/cryptokey_create.go
@@ -9,7 +9,7 @@ import (
 
 func (c *client) CreateCryptokey(ctx context.Context, serverID, zoneID string, opts Cryptokey) (*Cryptokey, error) {
 	cryptokey := Cryptokey{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/cryptokeys",
+	path := fmt.Sprintf("/servers/%s/zones/%s/cryptokeys",
 		url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	err := c.httpClient.Post(ctx, path, &cryptokey, pdnshttp.WithJSONRequestBody(opts))

--- a/apis/cryptokeys/cryptokey_create_test.go
+++ b/apis/cryptokeys/cryptokey_create_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mittwald/go-powerdns/pdnshttp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -34,7 +34,7 @@ func TestClient_CreateCryptokey(t *testing.T) {
 }`)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	cc := New(c)
 
 	key, err := cc.CreateCryptokey(context.Background(), "localhost", "pdns-test.de", Cryptokey{})

--- a/apis/cryptokeys/cryptokey_delete.go
+++ b/apis/cryptokeys/cryptokey_delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *client) DeleteCryptokey(ctx context.Context, serverID, zoneID string, cryptokeyID int) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/cryptokeys/%s",
+	path := fmt.Sprintf("/servers/%s/zones/%s/cryptokeys/%s",
 		url.PathEscape(serverID), url.PathEscape(zoneID), url.PathEscape(strconv.Itoa(cryptokeyID)))
 
 	return c.httpClient.Delete(ctx, path, nil)

--- a/apis/cryptokeys/cryptokey_delete_test.go
+++ b/apis/cryptokeys/cryptokey_delete_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mittwald/go-powerdns/pdnshttp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -16,7 +16,7 @@ func TestClient_DeleteCryptokey(t *testing.T) {
 		Reply(http.StatusNoContent)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	cc := New(c)
 
 	err := cc.DeleteCryptokey(context.Background(), "localhost", "pdns-test.de", 102)

--- a/apis/cryptokeys/cryptokey_get.go
+++ b/apis/cryptokeys/cryptokey_get.go
@@ -9,7 +9,7 @@ import (
 
 func (c *client) GetCryptokey(ctx context.Context, serverID, zoneID string, cryptokeyID int) (*Cryptokey, error) {
 	cryptokey := Cryptokey{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/cryptokeys/%s",
+	path := fmt.Sprintf("/servers/%s/zones/%s/cryptokeys/%s",
 		url.PathEscape(serverID), url.PathEscape(zoneID), url.PathEscape(strconv.Itoa(cryptokeyID)))
 
 	err := c.httpClient.Get(ctx, path, &cryptokey)

--- a/apis/cryptokeys/cryptokey_get_test.go
+++ b/apis/cryptokeys/cryptokey_get_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -35,7 +35,7 @@ func TestClient_GetCryptokey(t *testing.T) {
 }`)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	cc := New(c)
 
 	key, err := cc.GetCryptokey(context.Background(), "localhost", "pdns-test.de", 102)

--- a/apis/cryptokeys/cryptokey_list.go
+++ b/apis/cryptokeys/cryptokey_list.go
@@ -8,7 +8,7 @@ import (
 
 func (c *client) ListCryptokeys(ctx context.Context, serverID, zoneID string) ([]Cryptokey, error) {
 	cryptokeys := []Cryptokey{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/cryptokeys", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/cryptokeys", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	err := c.httpClient.Get(ctx, path, &cryptokeys)
 	if err != nil {

--- a/apis/cryptokeys/cryptokey_list_test.go
+++ b/apis/cryptokeys/cryptokey_list_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -36,7 +36,7 @@ func TestClient_ListCryptokeys(t *testing.T) {
 ]`)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	cc := New(c)
 
 	list, err := cc.ListCryptokeys(context.Background(), "localhost", "pdns-test.de")

--- a/apis/cryptokeys/cryptokey_toggle.go
+++ b/apis/cryptokeys/cryptokey_toggle.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *client) ToggleCryptokey(ctx context.Context, serverID, zoneID string, cryptokeyID int) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/cryptokeys/%s",
+	path := fmt.Sprintf("/servers/%s/zones/%s/cryptokeys/%s",
 		url.PathEscape(serverID), url.PathEscape(zoneID), url.PathEscape(strconv.Itoa(cryptokeyID)))
 
 	return c.httpClient.Put(ctx, path, nil)

--- a/apis/cryptokeys/cryptokey_toggle_test.go
+++ b/apis/cryptokeys/cryptokey_toggle_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mittwald/go-powerdns/pdnshttp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -16,7 +16,7 @@ func TestClient_ToggleCryptokey(t *testing.T) {
 		Reply(http.StatusNoContent)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	cc := New(c)
 
 	err := cc.ToggleCryptokey(context.Background(), "localhost", "pdns-test.de", 102)

--- a/apis/search/search.go
+++ b/apis/search/search.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *client) Search(ctx context.Context, serverID, query string, max int, objectType ObjectType) (ResultList, error) {
-	path := fmt.Sprintf("/api/v1/servers/%s/search-data", url.PathEscape(serverID))
+	path := fmt.Sprintf("/servers/%s/search-data", url.PathEscape(serverID))
 	results := make(ResultList, 0)
 
 	err := c.httpClient.Get(

--- a/apis/search/search_test.go
+++ b/apis/search/search_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mittwald/go-powerdns/pdnshttp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -37,7 +37,7 @@ func TestSearchExecutesCorrectRequest(t *testing.T) {
 				BodyString(exampleSearchResult)
 
 			hc := &http.Client{Transport: gock.DefaultTransport}
-			c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+			c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 			sc := New(c)
 
 			results, err := sc.Search(

--- a/apis/servers/servers_get.go
+++ b/apis/servers/servers_get.go
@@ -8,7 +8,7 @@ import (
 
 func (c *client) GetServer(ctx context.Context, serverID string) (*Server, error) {
 	server := Server{}
-	err := c.httpClient.Get(ctx, fmt.Sprintf("/api/v1/servers/%s", url.PathEscape(serverID)), &server)
+	err := c.httpClient.Get(ctx, fmt.Sprintf("/servers/%s", url.PathEscape(serverID)), &server)
 
 	if err != nil {
 		return nil, err

--- a/apis/servers/servers_list.go
+++ b/apis/servers/servers_list.go
@@ -5,7 +5,7 @@ import "context"
 func (c *client) ListServers(ctx context.Context) ([]Server, error) {
 	servers := make([]Server, 0)
 
-	err := c.httpClient.Get(ctx, "/api/v1/servers", &servers)
+	err := c.httpClient.Get(ctx, "/servers", &servers)
 	if err != nil {
 		return nil, err
 	}

--- a/apis/zones/zones_addrecordset.go
+++ b/apis/zones/zones_addrecordset.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *client) AddRecordSetToZone(ctx context.Context, serverID string, zoneID string, set ResourceRecordSet) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	set.ChangeType = ChangeTypeReplace
 	patch := Zone{

--- a/apis/zones/zones_create.go
+++ b/apis/zones/zones_create.go
@@ -10,7 +10,7 @@ import (
 
 func (c *client) CreateZone(ctx context.Context, serverID string, zone Zone) (*Zone, error) {
 	created := Zone{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones", url.PathEscape(serverID))
+	path := fmt.Sprintf("/servers/%s/zones", url.PathEscape(serverID))
 
 	zone.ID = ""
 	zone.Type = ZoneTypeZone

--- a/apis/zones/zones_create_test.go
+++ b/apis/zones/zones_create_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -66,7 +66,7 @@ func TestCreateZoneCreatesZone(t *testing.T) {
 		}`)
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := pdnshttp.NewClient("http://dns.example", hc, &pdnshttp.APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 	sc := New(c)
 
 	zone, err := sc.CreateZone(

--- a/apis/zones/zones_delete.go
+++ b/apis/zones/zones_delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) DeleteZone(ctx context.Context, serverID string, zoneID string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	return c.httpClient.Delete(ctx, path, nil)
 }

--- a/apis/zones/zones_export.go
+++ b/apis/zones/zones_export.go
@@ -11,7 +11,7 @@ import (
 
 func (c *client) ExportZone(ctx context.Context, serverID, zoneID string) ([]byte, error) {
 	output := bytes.Buffer{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/export", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/export", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	err := c.httpClient.Get(ctx, path, &output)
 	if err != nil {

--- a/apis/zones/zones_get.go
+++ b/apis/zones/zones_get.go
@@ -35,7 +35,7 @@ func WithResourceRecordSetFilter(name, recordType string) GetZoneOption {
 
 func (c *client) GetZone(ctx context.Context, serverID, zoneID string, opts ...GetZoneOption) (*Zone, error) {
 	zone := Zone{}
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	req, err := c.httpClient.NewRequest(http.MethodGet, path, nil)
 	if err != nil {

--- a/apis/zones/zones_list.go
+++ b/apis/zones/zones_list.go
@@ -10,7 +10,7 @@ import (
 
 func (c *client) ListZones(ctx context.Context, serverID string) ([]Zone, error) {
 	zones := make([]Zone, 0)
-	path := fmt.Sprintf("/api/v1/servers/%s/zones", url.PathEscape(serverID))
+	path := fmt.Sprintf("/servers/%s/zones", url.PathEscape(serverID))
 
 	err := c.httpClient.Get(ctx, path, &zones)
 	if err != nil {
@@ -22,7 +22,7 @@ func (c *client) ListZones(ctx context.Context, serverID string) ([]Zone, error)
 
 func (c *client) ListZone(ctx context.Context, serverID string, zoneName string) ([]Zone, error) {
 	zones := make([]Zone, 0)
-	path := fmt.Sprintf("/api/v1/servers/%s/zones", url.PathEscape(serverID))
+	path := fmt.Sprintf("/servers/%s/zones", url.PathEscape(serverID))
 
 	err := c.httpClient.Get(ctx, path, &zones, pdnshttp.WithQueryValue("zone", zoneName))
 	if err != nil {

--- a/apis/zones/zones_notifyslaves.go
+++ b/apis/zones/zones_notifyslaves.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) NotifySlaves(ctx context.Context, serverID string, zoneID string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/notify", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/notify", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	return c.httpClient.Put(ctx, path, nil)
 }

--- a/apis/zones/zones_rectify.go
+++ b/apis/zones/zones_rectify.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) RectifyZone(ctx context.Context, serverID string, zoneID string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/rectify", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/rectify", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	return c.httpClient.Put(ctx, path, nil)
 }

--- a/apis/zones/zones_removerecordset.go
+++ b/apis/zones/zones_removerecordset.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *client) RemoveRecordSetFromZone(ctx context.Context, serverID string, zoneID string, name string, recordType string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	set := ResourceRecordSet{
 		Name:       name,

--- a/apis/zones/zones_retrievemaster.go
+++ b/apis/zones/zones_retrievemaster.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) RetrieveFromMaster(ctx context.Context, serverID string, zoneID string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/axfr-retrieve", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/axfr-retrieve", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	return c.httpClient.Put(ctx, path, nil)
 }

--- a/apis/zones/zones_verify.go
+++ b/apis/zones/zones_verify.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *client) VerifyZone(ctx context.Context, serverID string, zoneID string) error {
-	path := fmt.Sprintf("/api/v1/servers/%s/zones/%s/check", url.PathEscape(serverID), url.PathEscape(zoneID))
+	path := fmt.Sprintf("/servers/%s/zones/%s/check", url.PathEscape(serverID), url.PathEscape(zoneID))
 
 	return c.httpClient.Get(ctx, path, nil)
 }

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/mittwald/go-powerdns/apis/cryptokeys"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -37,7 +36,7 @@ func New(opt ...ClientOption) (Client, error) {
 	c := client{
 		baseURL:       "http://localhost:8081",
 		httpClient:    http.DefaultClient,
-		debugOutput:   ioutil.Discard,
+		debugOutput:   io.Discard,
 		authenticator: &pdnshttp.NoopAuthenticator{},
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mittwald/go-powerdns/pdnshttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -417,7 +417,7 @@ func TestExportZone(t *testing.T) {
 }
 
 func buildClient(t *testing.T) Client {
-	debug := ioutil.Discard
+	debug := io.Discard
 
 	if testing.Verbose() {
 		debug = os.Stderr

--- a/pdnshttp/client.go
+++ b/pdnshttp/client.go
@@ -24,14 +24,13 @@ func NewClient(baseURL string, hc *http.Client, auth ClientAuthenticator, debugO
 	if err != nil {
 		panic(err)
 	}
-	var path string
 	if strings.TrimSuffix(u.Path, "/") == "" {
-		path = "/api/v1"
+		u.Path = "/api/v1"
 	} else {
-		path = strings.TrimSuffix(u.Path, "/")
+		u.Path = strings.TrimSuffix(u.Path, "/")
 	}
 	c := Client{
-		baseURL:       strings.TrimSuffix(baseURL, "/") + path,
+		baseURL:       u.Scheme + "://" + u.Host + u.Path,
 		httpClient:    hc,
 		authenticator: auth,
 		debugOutput:   debugOutput,

--- a/pdnshttp/client.go
+++ b/pdnshttp/client.go
@@ -30,7 +30,7 @@ func NewClient(baseURL string, hc *http.Client, auth ClientAuthenticator, debugO
 		u.Path = strings.TrimSuffix(u.Path, "/")
 	}
 	c := Client{
-		baseURL:       u.String()
+		baseURL:       u.String(),
 		httpClient:    hc,
 		authenticator: auth,
 		debugOutput:   debugOutput,

--- a/pdnshttp/client.go
+++ b/pdnshttp/client.go
@@ -30,7 +30,7 @@ func NewClient(baseURL string, hc *http.Client, auth ClientAuthenticator, debugO
 		u.Path = strings.TrimSuffix(u.Path, "/")
 	}
 	c := Client{
-		baseURL:       u.Scheme + "://" + u.Host + u.Path,
+		baseURL:       u.String()
 		httpClient:    hc,
 		authenticator: auth,
 		debugOutput:   debugOutput,

--- a/pdnshttp/client.go
+++ b/pdnshttp/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"strings"
 )
 
@@ -19,8 +20,18 @@ type Client struct {
 
 // NewClient returns a new PowerDNS HTTP client
 func NewClient(baseURL string, hc *http.Client, auth ClientAuthenticator, debugOutput io.Writer) *Client {
+	u, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		panic(err)
+	}
+	var path string
+	if strings.TrimSuffix(u.Path, "/") == "" {
+		path = "/api/v1"
+	} else {
+		path = strings.TrimSuffix(u.Path, "/")
+	}
 	c := Client{
-		baseURL:       baseURL,
+		baseURL:       strings.TrimSuffix(baseURL, "/") + path,
 		httpClient:    hc,
 		authenticator: auth,
 		debugOutput:   debugOutput,

--- a/pdnshttp/client_test.go
+++ b/pdnshttp/client_test.go
@@ -21,7 +21,24 @@ func TestGetExecutedCorrectly(t *testing.T) {
 
 	var out interface{}
 
-	err := c.Get(context.Background(), "/api/v1/servers2", &out)
+	err := c.Get(context.Background(), "/servers", &out)
+	require.Nil(t, err)
+	require.True(t, gock.IsDone(), "still has pending mocks")
+}
+
+func TestBaseURLAlreadyContainsPath(t *testing.T) {
+	gock.New("http://test.example").
+		Get("/api/v2/servers").
+		MatchHeader("X-API-Key", "secret").
+		Reply(http.StatusOK).
+		JSON(map[string]string{"foo": "bar"})
+
+	hc := &http.Client{Transport: gock.DefaultTransport}
+	c := NewClient("http://test.example/api/v2", hc, &APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
+
+	var out interface{}
+
+	err := c.Get(context.Background(), "/servers", &out)
 	require.Nil(t, err)
 	require.True(t, gock.IsDone(), "still has pending mocks")
 }

--- a/pdnshttp/client_test.go
+++ b/pdnshttp/client_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestGetExecutedCorrectly(t *testing.T) {
 		JSON(map[string]string{"foo": "bar"})
 
 	hc := &http.Client{Transport: gock.DefaultTransport}
-	c := NewClient("http://test.example", hc, &APIKeyAuthenticator{APIKey: "secret"}, ioutil.Discard)
+	c := NewClient("http://test.example", hc, &APIKeyAuthenticator{APIKey: "secret"}, io.Discard)
 
 	var out interface{}
 


### PR DESCRIPTION
Configure the base path to use when constructing the powerdns client. This allows a user to specify its own base path in case the PowerDNS server API is running on a different base path than the default `/api/v1`.