### PR TITLE
Adds catalog zone support

### DIFF
--- a/apis/zones/types_zonekind.go
+++ b/apis/zones/types_zonekind.go
@@ -9,6 +9,8 @@ const (
 	ZoneKindNative ZoneKind = iota
 	ZoneKindMaster
 	ZoneKindSlave
+	ZoneKindProducer
+	ZoneKindConsumer
 )
 
 func (k ZoneKind) MarshalJSON() ([]byte, error) {
@@ -19,6 +21,10 @@ func (k ZoneKind) MarshalJSON() ([]byte, error) {
 		return []byte(`"Master"`), nil
 	case ZoneKindSlave:
 		return []byte(`"Slave"`), nil
+	case ZoneKindProducer:
+		return []byte(`"Producer"`), nil
+	case ZoneKindConsumer:
+		return []byte(`"Consumer"`), nil
 	default:
 		return nil, fmt.Errorf("unsupported zone kind: %d", k)
 	}
@@ -32,6 +38,10 @@ func (k *ZoneKind) UnmarshalJSON(input []byte) error {
 		*k = ZoneKindMaster
 	case `"Slave"`:
 		*k = ZoneKindSlave
+	case `"Producer"`:
+		*k = ZoneKindProducer
+	case `"Consumer"`:
+		*k = ZoneKindConsumer
 	default:
 		return fmt.Errorf("unsupported zone kind: %s", string(input))
 	}

--- a/apis/zones/types_zonekind_test.go
+++ b/apis/zones/types_zonekind_test.go
@@ -1,0 +1,69 @@
+package zones
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+func TestZoneKindSerializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneKind
+		e string
+	}{
+		{ZoneKindNative, `"Native"`},
+		{ZoneKindMaster, `"Master"`},
+		{ZoneKindSlave, `"Slave"`},
+		{ZoneKindProducer, `"Producer"`},
+		{ZoneKindConsumer, `"Consumer"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			j, err := json.Marshal(data[i].v)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].e, string(j))
+		})
+	}
+}
+
+func TestZoneTypeSerializationReturnErrorOnUnknownValue(t *testing.T) {
+	var v ZoneKind = 123
+
+	_, err := json.Marshal(v)
+	assert.NotNil(t, err)
+}
+
+func TestZoneKindUnserializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneKind
+		e string
+	}{
+		{ZoneKindNative, `"Native"`},
+		{ZoneKindMaster, `"Master"`},
+		{ZoneKindSlave, `"Slave"`},
+		{ZoneKindProducer, `"Producer"`},
+		{ZoneKindConsumer, `"Consumer"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			var out ZoneKind
+
+			err := json.Unmarshal([]byte(data[i].e), &out)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].v, out)
+		})
+	}
+}
+
+func TestZoneKindUnserializationReturnErrorOnUnknownValue(t *testing.T) {
+	e := []byte(`"FOO"`)
+
+	var out ZoneKind
+
+	err := json.Unmarshal(e, &out)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Title says it all :-)

https://doc.powerdns.com/authoritative/catalog.html

> Starting with the PowerDNS Authoritative Server 4.7.0, catalog zone support is available.

https://doc.powerdns.com/authoritative/http-api/zone.html#objects

> kind (string) – Zone kind, one of “Native”, “Master”, “Slave”, “Producer”, “Consumer”