### PR TITLE
Feature: Add function to zones API to add multiple ResourceRecordSets at once

### DIFF
--- a/apis/zones/interface.go
+++ b/apis/zones/interface.go
@@ -24,6 +24,10 @@ type Client interface {
 	// the exact name/type combination will be replaced.
 	AddRecordSetToZone(ctx context.Context, serverID string, zoneID string, set ResourceRecordSet) error
 
+	// AddRecordSetsToZone will add new sets of records to a zone. Existing record sets for
+	// the exact name/type combination will be replaced.
+	AddRecordSetsToZone(ctx context.Context, serverID string, zoneID string, sets []ResourceRecordSet) error
+
 	// RemoveRecordSetFromZone removes a record set from a zone. The record set is matched
 	// by name and type.
 	RemoveRecordSetFromZone(ctx context.Context, serverID string, zoneID string, name string, recordType string) error

--- a/apis/zones/interface.go
+++ b/apis/zones/interface.go
@@ -22,6 +22,8 @@ type Client interface {
 
 	// AddRecordSetToZone will add a new set of records to a zone. Existing record sets for
 	// the exact name/type combination will be replaced.
+	//
+	// Deprecated: Superceded by AddRecordSetsToZone
 	AddRecordSetToZone(ctx context.Context, serverID string, zoneID string, set ResourceRecordSet) error
 
 	// AddRecordSetsToZone will add new sets of records to a zone. Existing record sets for

--- a/apis/zones/zones_addrecordset.go
+++ b/apis/zones/zones_addrecordset.go
@@ -9,16 +9,7 @@ import (
 )
 
 func (c *client) AddRecordSetToZone(ctx context.Context, serverID string, zoneID string, set ResourceRecordSet) error {
-	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
-
-	set.ChangeType = ChangeTypeReplace
-	patch := Zone{
-		ResourceRecordSets: []ResourceRecordSet{
-			set,
-		},
-	}
-
-	return c.httpClient.Patch(ctx, path, nil, pdnshttp.WithJSONRequestBody(&patch))
+	return c.AddRecordSetsToZone(ctx, serverID, zoneID, []ResourceRecordSet{set})
 }
 
 func (c *client) AddRecordSetsToZone(ctx context.Context, serverID string, zoneID string, sets []ResourceRecordSet) error {

--- a/apis/zones/zones_addrecordset.go
+++ b/apis/zones/zones_addrecordset.go
@@ -3,8 +3,9 @@ package zones
 import (
 	"context"
 	"fmt"
-	"github.com/mittwald/go-powerdns/pdnshttp"
 	"net/url"
+
+	"github.com/mittwald/go-powerdns/pdnshttp"
 )
 
 func (c *client) AddRecordSetToZone(ctx context.Context, serverID string, zoneID string, set ResourceRecordSet) error {
@@ -15,6 +16,19 @@ func (c *client) AddRecordSetToZone(ctx context.Context, serverID string, zoneID
 		ResourceRecordSets: []ResourceRecordSet{
 			set,
 		},
+	}
+
+	return c.httpClient.Patch(ctx, path, nil, pdnshttp.WithJSONRequestBody(&patch))
+}
+
+func (c *client) AddRecordSetsToZone(ctx context.Context, serverID string, zoneID string, sets []ResourceRecordSet) error {
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+
+	for idx := range sets {
+		sets[idx].ChangeType = ChangeTypeReplace
+	}
+	patch := Zone{
+		ResourceRecordSets: sets,
 	}
 
 	return c.httpClient.Patch(ctx, path, nil, pdnshttp.WithJSONRequestBody(&patch))

--- a/client_test.go
+++ b/client_test.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/mittwald/go-powerdns/apis/search"
-	"github.com/mittwald/go-powerdns/apis/zones"
-	"github.com/mittwald/go-powerdns/pdnshttp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/mittwald/go-powerdns/apis/search"
+	"github.com/mittwald/go-powerdns/apis/zones"
+	"github.com/mittwald/go-powerdns/pdnshttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -24,12 +25,12 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	runOrPanic("docker-compose", "rm", "-sfv")
-	runOrPanic("docker-compose", "down", "-v")
-	runOrPanic("docker-compose", "up", "-d")
+	runOrPanic("docker", "compose", "rm", "-sfv")
+	runOrPanic("docker", "compose", "down", "-v")
+	runOrPanic("docker", "compose", "up", "-d")
 
 	defer func() {
-		runOrPanic("docker-compose", "down", "-v")
+		runOrPanic("docker", "compose", "down", "-v")
 	}()
 
 	c, err := New(
@@ -53,7 +54,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Leaving containers running for further inspection")
 		fmt.Println("")
 	} else {
-		runOrPanic("docker-compose", "down", "-v")
+		runOrPanic("docker", "compose", "down", "-v")
 	}
 
 	os.Exit(e)
@@ -410,7 +411,7 @@ func TestExportZone(t *testing.T) {
 
 	export, sErr := c.Zones().ExportZone(ctx, "localhost", created.ID)
 
-	date := time.Now().Format("20060102") + "01"
+	date := time.Now().UTC().Format("20060102") + "01"
 
 	require.Nil(t, sErr)
 	require.Equal(t, "example-export.de.\t60\tIN\tA\t127.0.0.1\nexample-export.de.\t3600\tIN\tNS\tns1.example.com.\nexample-export.de.\t3600\tIN\tNS\tns2.example.com.\nexample-export.de.\t3600\tIN\tSOA\ta.misconfigured.dns.server.invalid. hostmaster.example-export.de. "+date+" 10800 3600 604800 3600\n", string(export))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
 services:
   powerdns:
-    image: powerdns/pdns-auth-46:4.6.3
+    image: powerdns/pdns-auth-49:4.9.1
     environment:
       PDNS_AUTH_API_KEY: secret
     ports:


### PR DESCRIPTION
PowerDNS' API allows adding multiple records at the same time, but the current go-powerdns API limits this to a single `ResourceRecordSet`. This new function, `AddRecordSetsToZone` (added the `s`), allows an array to be passed allowing batch updates of multiple DNS records.