### PR TITLE
Feature: Add function to zones API to remove multiple ResourceRecordSets at once

### DIFF
--- a/apis/zones/interface.go
+++ b/apis/zones/interface.go
@@ -32,6 +32,8 @@ type Client interface {
 
 	// RemoveRecordSetFromZone removes a record set from a zone. The record set is matched
 	// by name and type.
+	//
+	// Deprecated: Superceded by RemoveRecordSetsFromZone
 	RemoveRecordSetFromZone(ctx context.Context, serverID string, zoneID string, name string, recordType string) error
 
 	// RemoveRecordSetsFromZone removes record sets from a zone. The record sets are matched

--- a/apis/zones/interface.go
+++ b/apis/zones/interface.go
@@ -34,6 +34,10 @@ type Client interface {
 	// by name and type.
 	RemoveRecordSetFromZone(ctx context.Context, serverID string, zoneID string, name string, recordType string) error
 
+	// RemoveRecordSetsFromZone removes record sets from a zone. The record sets are matched
+	// by name and type.
+	RemoveRecordSetsFromZone(ctx context.Context, serverID string, zoneID string, sets []ResourceRecordSet) error
+
 	// RetrieveFromMaster retrieves a slave zone from its master
 	RetrieveFromMaster(ctx context.Context, serverID string, zoneID string) error
 

--- a/apis/zones/zones_removerecordset.go
+++ b/apis/zones/zones_removerecordset.go
@@ -3,21 +3,29 @@ package zones
 import (
 	"context"
 	"fmt"
-	"github.com/mittwald/go-powerdns/pdnshttp"
 	"net/url"
+
+	"github.com/mittwald/go-powerdns/pdnshttp"
 )
 
 func (c *client) RemoveRecordSetFromZone(ctx context.Context, serverID string, zoneID string, name string, recordType string) error {
-	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
-
 	set := ResourceRecordSet{
 		Name:       name,
 		Type:       recordType,
 		ChangeType: ChangeTypeDelete,
 	}
 
+	return c.RemoveRecordSetsFromZone(ctx, serverID, zoneID, []ResourceRecordSet{set})
+}
+
+func (c *client) RemoveRecordSetsFromZone(ctx context.Context, serverID string, zoneID string, sets []ResourceRecordSet) error {
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+
+	for idx := range sets {
+		sets[idx].ChangeType = ChangeTypeDelete
+	}
 	patch := Zone{
-		ResourceRecordSets: []ResourceRecordSet{set},
+		ResourceRecordSets: sets,
 	}
 
 	return c.httpClient.Patch(ctx, path, nil, pdnshttp.WithJSONRequestBody(&patch))


### PR DESCRIPTION
PowerDNS' API allows removing multiple records at the same time, but the current `RemoveRecordSetFromZone` is limited to a single `ResourceRecordSet` generated from the `name` and `recordType` strings. This new function, `RemoveRecordSetsFromZone` allows passing an array of `ResourceRecordSet`s instead of just a name and record type string. This additionally adds parity between the add and remove interface.

From the prior PR and talking about deprecating the old function, I've taken the initiative to add the deprecation commit already. :)