### PR TITLE
Add support for zone PUT route / modify basic zone data

### DIFF
--- a/apis/zones/interface.go
+++ b/apis/zones/interface.go
@@ -54,4 +54,7 @@ type Client interface {
 
 	// RectifyZone rectifies the zone data
 	RectifyZone(ctx context.Context, serverID string, zoneID string) error
+
+	// Modifies basic zone data
+	ModifyBasicZoneData(ctx context.Context, serverID string, zoneID string, update ZoneBasicDataUpdate) error
 }

--- a/apis/zones/types_zone.go
+++ b/apis/zones/types_zone.go
@@ -30,8 +30,8 @@ type Zone struct {
 	NSec3Param         string              `json:"nsec3param,omitempty"`
 	NSec3Narrow        bool                `json:"nsec3narrow,omitempty"`
 	Presigned          bool                `json:"presigned,omitempty"`
-	SOAEdit            string              `json:"soa_edit,omitempty"`
-	SOAEditAPI         string              `json:"soa_edit_api,omitempty"`
+	SOAEdit            ZoneSOAEdit         `json:"soa_edit,omitempty"`
+	SOAEditAPI         ZoneSOAEditAPI      `json:"soa_edit_api,omitempty"`
 	APIRectify         bool                `json:"api_rectify,omitempty"`
 	Zone               string              `json:"zone,omitempty"`
 	Account            string              `json:"account,omitempty"`

--- a/apis/zones/types_zonesoaedit.go
+++ b/apis/zones/types_zonesoaedit.go
@@ -1,0 +1,51 @@
+package zones
+
+import "fmt"
+
+type ZoneSOAEdit int
+
+const (
+	ZoneSOAEditUnset          ZoneSOAEdit = iota
+	ZoneSOAEditIncrementWeeks             = iota
+	ZoneSOAEditInceptionEpoch
+	ZoneSOAEditInceptionIncrement
+	ZoneSOAEditEpoch
+	ZoneSOAEditNone
+)
+
+func (v ZoneSOAEdit) MarshalJSON() ([]byte, error) {
+	switch v {
+	case ZoneSOAEditIncrementWeeks:
+		return []byte(`"INCREMENT-WEEKS"`), nil
+	case ZoneSOAEditInceptionEpoch:
+		return []byte(`"INCEPTION-EPOCH"`), nil
+	case ZoneSOAEditInceptionIncrement:
+		return []byte(`"INCEPTION-INCREMENT"`), nil
+	case ZoneSOAEditEpoch:
+		return []byte(`"EPOCH"`), nil
+	case ZoneSOAEditNone:
+		return []byte(`"NONE"`), nil
+	default:
+		return nil, fmt.Errorf("unsupported SOA-EDIT value: %d", v)
+	}
+}
+
+func (v *ZoneSOAEdit) UnmarshalJSON(input []byte) error {
+	switch string(input) {
+	case `"INCREMENT-WEEKS"`:
+		*v = ZoneSOAEditIncrementWeeks
+	case `"INCEPTION-EPOCH"`:
+		*v = ZoneSOAEditInceptionEpoch
+	case `"INCEPTION-INCREMENT"`:
+		*v = ZoneSOAEditInceptionIncrement
+	case `"EPOCH"`:
+		*v = ZoneSOAEditEpoch
+	case `"NONE"`:
+		*v = ZoneSOAEditNone
+	case `""`:
+		*v = ZoneSOAEditUnset
+	default:
+		return fmt.Errorf("unsupported SOA-EDIT value: %s", string(input))
+	}
+	return nil
+}

--- a/apis/zones/types_zonesoaedit_test.go
+++ b/apis/zones/types_zonesoaedit_test.go
@@ -1,0 +1,71 @@
+package zones
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZoneSOAEditSerializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneSOAEdit
+		e string
+	}{
+		{ZoneSOAEditIncrementWeeks, `"INCREMENT-WEEKS"`},
+		{ZoneSOAEditInceptionEpoch, `"INCEPTION-EPOCH"`},
+		{ZoneSOAEditInceptionIncrement, `"INCEPTION-INCREMENT"`},
+		{ZoneSOAEditEpoch, `"EPOCH"`},
+		{ZoneSOAEditNone, `"NONE"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			j, err := json.Marshal(data[i].v)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].e, string(j))
+		})
+	}
+}
+
+func TestZoneSOAEditSerializationReturnErrorOnUnknownValue(t *testing.T) {
+	var v ZoneSOAEdit = 123
+
+	_, err := json.Marshal(v)
+	assert.NotNil(t, err)
+}
+
+func TestZoneSOAEditUnserializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneSOAEdit
+		e string
+	}{
+		{ZoneSOAEditIncrementWeeks, `"INCREMENT-WEEKS"`},
+		{ZoneSOAEditInceptionEpoch, `"INCEPTION-EPOCH"`},
+		{ZoneSOAEditInceptionIncrement, `"INCEPTION-INCREMENT"`},
+		{ZoneSOAEditEpoch, `"EPOCH"`},
+		{ZoneSOAEditNone, `"NONE"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			var out ZoneSOAEdit
+
+			err := json.Unmarshal([]byte(data[i].e), &out)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].v, out)
+		})
+	}
+}
+
+func TestZoneSOAEditUnserializationReturnErrorOnUnknownValue(t *testing.T) {
+	e := []byte(`"FOO"`)
+
+	var out ZoneSOAEdit
+
+	err := json.Unmarshal(e, &out)
+	assert.NotNil(t, err)
+}

--- a/apis/zones/types_zonesoaeditapi.go
+++ b/apis/zones/types_zonesoaeditapi.go
@@ -1,0 +1,54 @@
+package zones
+
+import "fmt"
+
+type ZoneSOAEditAPI int
+
+const (
+	_                                    = iota
+	ZoneSOAEditAPIDefault ZoneSOAEditAPI = iota
+	ZoneSOAEditAPIIncrease
+	ZoneSOAEditAPIEpoch
+	ZoneSOAEditAPISoaEdit
+	ZoneSOAEditAPISoaEditIncrease
+	ZoneSOAEditAPINone
+)
+
+func (v ZoneSOAEditAPI) MarshalJSON() ([]byte, error) {
+	switch v {
+	case ZoneSOAEditAPIDefault:
+		return []byte(`"DEFAULT"`), nil
+	case ZoneSOAEditAPIIncrease:
+		return []byte(`"INCREASE"`), nil
+	case ZoneSOAEditAPIEpoch:
+		return []byte(`"EPOCH"`), nil
+	case ZoneSOAEditAPISoaEdit:
+		return []byte(`"SOA-EDIT"`), nil
+	case ZoneSOAEditAPISoaEditIncrease:
+		return []byte(`"SOA-EDIT-INCREASE"`), nil
+	case ZoneSOAEditAPINone:
+		return []byte(`"NONE"`), nil
+	default:
+		return nil, fmt.Errorf("unsupported SOA-EDIT-API value: %d", v)
+	}
+}
+
+func (v *ZoneSOAEditAPI) UnmarshalJSON(input []byte) error {
+	switch string(input) {
+	case `"DEFAULT"`:
+		*v = ZoneSOAEditAPIDefault
+	case `"INCREASE"`:
+		*v = ZoneSOAEditAPIIncrease
+	case `"EPOCH"`:
+		*v = ZoneSOAEditAPIEpoch
+	case `"SOA-EDIT"`:
+		*v = ZoneSOAEditAPISoaEdit
+	case `"SOA-EDIT-INCREASE"`:
+		*v = ZoneSOAEditAPISoaEditIncrease
+	case `"NONE"`:
+		*v = ZoneSOAEditAPINone
+	default:
+		return fmt.Errorf("unsupported SOA-EDIT-API value: %s", string(input))
+	}
+	return nil
+}

--- a/apis/zones/types_zonesoaeditapi_test.go
+++ b/apis/zones/types_zonesoaeditapi_test.go
@@ -1,0 +1,73 @@
+package zones
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZoneSOAEditAPISerializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneSOAEditAPI
+		e string
+	}{
+		{ZoneSOAEditAPIDefault, `"DEFAULT"`},
+		{ZoneSOAEditAPIIncrease, `"INCREASE"`},
+		{ZoneSOAEditAPIEpoch, `"EPOCH"`},
+		{ZoneSOAEditAPISoaEdit, `"SOA-EDIT"`},
+		{ZoneSOAEditAPISoaEditIncrease, `"SOA-EDIT-INCREASE"`},
+		{ZoneSOAEditAPINone, `"NONE"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			j, err := json.Marshal(data[i].v)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].e, string(j))
+		})
+	}
+}
+
+func TestZoneSOAEditAPISerializationReturnErrorOnUnknownValue(t *testing.T) {
+	var v ZoneSOAEditAPI = 123
+
+	_, err := json.Marshal(v)
+	assert.NotNil(t, err)
+}
+
+func TestZoneSOAEditAPIUnserializesCorrectly(t *testing.T) {
+	data := []struct {
+		v ZoneSOAEditAPI
+		e string
+	}{
+		{ZoneSOAEditAPIDefault, `"DEFAULT"`},
+		{ZoneSOAEditAPIIncrease, `"INCREASE"`},
+		{ZoneSOAEditAPIEpoch, `"EPOCH"`},
+		{ZoneSOAEditAPISoaEdit, `"SOA-EDIT"`},
+		{ZoneSOAEditAPISoaEditIncrease, `"SOA-EDIT-INCREASE"`},
+		{ZoneSOAEditAPINone, `"NONE"`},
+	}
+
+	for i := range data {
+		t.Run(fmt.Sprintf("serializes to %s", data[i].e), func(t *testing.T) {
+			var out ZoneSOAEditAPI
+
+			err := json.Unmarshal([]byte(data[i].e), &out)
+
+			assert.Nil(t, err)
+			assert.Equal(t, data[i].v, out)
+		})
+	}
+}
+
+func TestZoneSOAEditAPIUnserializationReturnErrorOnUnknownValue(t *testing.T) {
+	e := []byte(`"FOO"`)
+
+	var out ZoneSOAEditAPI
+
+	err := json.Unmarshal(e, &out)
+	assert.NotNil(t, err)
+}

--- a/apis/zones/zones_modifybasicdata.go
+++ b/apis/zones/zones_modifybasicdata.go
@@ -1,0 +1,30 @@
+package zones
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/mittwald/go-powerdns/pdnshttp"
+)
+
+type ZoneBasicDataUpdate struct {
+	Kind       ZoneKind       `json:"kind,omitempty"`
+	Masters    []string       `json:"masters,omitempty"`
+	Account    string         `json:"account,omitempty"`
+	SOAEdit    ZoneSOAEdit    `json:"soa_edit,omitempty"`
+	SOAEditAPI ZoneSOAEditAPI `json:"soa_edit_api,omitempty"`
+	APIRectify *bool          `json:"api_rectify,omitempty"`
+	DNSSec     *bool          `json:"dnssec,omitempty"`
+	NSec3Param string         `json:"nsec3param,omitempty"`
+}
+
+func (c *client) ModifyBasicZoneData(ctx context.Context, serverID string, zoneID string, update ZoneBasicDataUpdate) error {
+	path := fmt.Sprintf("/servers/%s/zones/%s", url.PathEscape(serverID), url.PathEscape(zoneID))
+
+	err := c.httpClient.Put(ctx, path, nil, pdnshttp.WithJSONRequestBody(&update))
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The Zones API has a [PUT route to modify "basic zone data"](https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id). Implementing it allows us to set some zone metadata (i.e `SOA-EDIT-API`) for existing Zones.

I also added enum types for `SOAEdit` and `SOAEditAPI`, which *is* a breaking change. If you don't want that, let me know or remove them from the PR.
