### PR TITLE
chore: bump Go to recent versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.17', '1.16' ]
+        go: [ '1.24', '1.23', '1.22' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mittwald/go-powerdns
 
-go 1.18
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
This PR bumps both the Go version in go.mod and the versions that are tested
against to the three most recent versions.
